### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,13 +1,9 @@
 version: 2.1
 description: |
   Integrate your CircleCI workflows and jobs pipeline with Coralogix to automatically receive reports and analyze version upgrades for their impact on the overall quality of your production system.
-  Coralogix Orb provides four tools at your disposal:
-    coralogix/stats (job) - send the final report of a workflow job to Coralogix.
-    coralogix/logs (job) - send logs of workflow jobs to Coralogix for debugging.
-    coralogix/send (command) - send additional 3rd party logs generated during your workflow job to Coralogix.
-    coralogix/tag (command) - create a tag (and a report) for the workflow in Coralogix.
-  Website: http:/www.coralogix.com
   Learn more: https://coralogix.com/category/tutorials/
-  Repository: https://github.com/coralogix-circleci/coralogix-orb
+display:
+  home_url: http:/www.coralogix.com
+  source_url: https://github.com/coralogix-circleci/coralogix-orb
 orbs:
   jq: circleci/jq@1.9.0


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.

Removed redundant description of components as well, as the components contain their own descriptions.